### PR TITLE
Feat: 스웨거 에러 response 리스트화 기능 추가

### DIFF
--- a/src/main/java/com/team2/finalproject/domain/deliverydestination/controller/SwaggerDeliveryDestinationController.java
+++ b/src/main/java/com/team2/finalproject/domain/deliverydestination/controller/SwaggerDeliveryDestinationController.java
@@ -1,26 +1,30 @@
 package com.team2.finalproject.domain.deliverydestination.controller;
 
+import com.team2.finalproject.domain.center.exception.CenterErrorCode;
+import com.team2.finalproject.domain.deliverydestination.exception.DeliveryDestinationErrorCode;
 import com.team2.finalproject.domain.deliverydestination.model.dto.request.DeliveryDestinationRequest;
 import com.team2.finalproject.domain.deliverydestination.model.dto.request.UpdateDeliveryDestinationRequest;
 import com.team2.finalproject.domain.deliverydestination.model.dto.response.DeliveryDestinationResponse;
+import com.team2.finalproject.global.annotation.ApiErrorResponse;
+import com.team2.finalproject.global.annotation.ApiErrorResponses;
+import com.team2.finalproject.global.security.exception.SecurityErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Delivery Destination", description = "배송처")
 public interface SwaggerDeliveryDestinationController {
     @Operation(summary = "배송처 상세 정보 조회", description = "배송처의 상세 정보를 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "배송처 상세 정보 조회 성공", content = @Content(schema = @Schema(implementation = DeliveryDestinationResponse.class))),
-            @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 배송처", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "200", description = "배송처 상세 정보 조회 성공", content = @Content(schema = @Schema(implementation = DeliveryDestinationResponse.class)))
+    @ApiErrorResponses({
+            @ApiErrorResponse(value = SecurityErrorCode.class, enumName = "UNAUTHORIZED_ACCESS"),
+            @ApiErrorResponse(value = CenterErrorCode.class, enumName = "NOT_FOUND_CENTER"),
+            @ApiErrorResponse(value = DeliveryDestinationErrorCode.class, enumName = "NOT_FOUND_DELIVERY_DESTINATION")
     })
     ResponseEntity<?> getDeliveryDestination(@PathVariable(value = "deliveryDestinationId") long deliveryDestinationId);
 
@@ -28,10 +32,10 @@ public interface SwaggerDeliveryDestinationController {
     ResponseEntity<?> addDeliveryDestination(@RequestBody DeliveryDestinationRequest request);
 
     @Operation(summary = "배송처 상세정보 변경", description = "배송처에 대한 상세정보를 변경합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "배송처 상세정보 변경 성공"),
-            @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 배송처", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "200", description = "배송처 상세정보 변경 성공")
+    @ApiErrorResponses({
+            @ApiErrorResponse(value = SecurityErrorCode.class, enumName = "UNAUTHORIZED_ACCESS"),
+            @ApiErrorResponse(value = DeliveryDestinationErrorCode.class, enumName = "NOT_FOUND_DELIVERY_DESTINATION")
     })
     ResponseEntity<?> updateDeliveryDestination(@PathVariable long deliveryDestinationId,
                                                 @RequestBody UpdateDeliveryDestinationRequest request);

--- a/src/main/java/com/team2/finalproject/global/annotation/ApiErrorResponse.java
+++ b/src/main/java/com/team2/finalproject/global/annotation/ApiErrorResponse.java
@@ -1,0 +1,21 @@
+package com.team2.finalproject.global.annotation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import com.team2.finalproject.global.exception.errorcode.ErrorCode;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({METHOD, TYPE, ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Repeatable(ApiErrorResponses.class)
+public @interface ApiErrorResponse {
+    Class<? extends ErrorCode> value();
+    String enumName();
+}

--- a/src/main/java/com/team2/finalproject/global/annotation/ApiErrorResponses.java
+++ b/src/main/java/com/team2/finalproject/global/annotation/ApiErrorResponses.java
@@ -15,4 +15,3 @@ import java.lang.annotation.Target;
 public @interface ApiErrorResponses {
     ApiErrorResponse[] value() default {};
 }
-//https://github.com/depromeet/street-drop-server/blob/dev/backend/streetdrop-api/src/main/java/com/depromeet/external/swagger/config/CustomOperationCustomizer.java

--- a/src/main/java/com/team2/finalproject/global/annotation/ApiErrorResponses.java
+++ b/src/main/java/com/team2/finalproject/global/annotation/ApiErrorResponses.java
@@ -1,0 +1,18 @@
+package com.team2.finalproject.global.annotation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({METHOD, TYPE, ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface ApiErrorResponses {
+    ApiErrorResponse[] value() default {};
+}
+//https://github.com/depromeet/street-drop-server/blob/dev/backend/streetdrop-api/src/main/java/com/depromeet/external/swagger/config/CustomOperationCustomizer.java

--- a/src/main/java/com/team2/finalproject/global/config/SwaggerConfig.java
+++ b/src/main/java/com/team2/finalproject/global/config/SwaggerConfig.java
@@ -1,15 +1,27 @@
 package com.team2.finalproject.global.config;
 
+import com.team2.finalproject.global.swagger.customizer.CustomOperationCustomizer;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
+
+    @Value("${server.url}")
+    String requestUrl;
+
+
+    private final CustomOperationCustomizer customOperationCustomizer;
+
     @Bean
     public OpenAPI openAPI() {
         String jwt = "JWT";
@@ -27,6 +39,17 @@ public class SwaggerConfig {
                 .addSecurityItem(securityRequirement)
                 .components(components);
     }
+
+
+    @Bean
+    public GroupedOpenApi errorOpenApi() {
+        return GroupedOpenApi.builder()
+                .group("v1")
+                .pathsToMatch("/**")
+                .addOperationCustomizer(customOperationCustomizer)
+                .build();
+    }
+
     private Info apiInfo() {
         return new Info()
                 .title("GLT KOREA TMS")

--- a/src/main/java/com/team2/finalproject/global/exception/response/ErrorResponse.java
+++ b/src/main/java/com/team2/finalproject/global/exception/response/ErrorResponse.java
@@ -1,8 +1,17 @@
 package com.team2.finalproject.global.exception.response;
 
+import com.team2.finalproject.global.exception.errorcode.ErrorCode;
+import lombok.Builder;
+
+@Builder
 public record ErrorResponse (
         String statusMessage,
         String message
 ){
-
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .statusMessage(errorCode.getHttpStatus().getReasonPhrase())
+                .message(errorCode.getMessage())
+                .build();
+    }
 }

--- a/src/main/java/com/team2/finalproject/global/swagger/customizer/CustomOperationCustomizer.java
+++ b/src/main/java/com/team2/finalproject/global/swagger/customizer/CustomOperationCustomizer.java
@@ -1,0 +1,80 @@
+package com.team2.finalproject.global.swagger.customizer;
+
+import com.team2.finalproject.global.annotation.ApiErrorResponse;
+import com.team2.finalproject.global.annotation.ApiErrorResponses;
+import com.team2.finalproject.global.exception.errorcode.ErrorCode;
+import io.swagger.v3.oas.models.Operation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOperationCustomizer implements OperationCustomizer {
+
+    private final ErrorResponseExampleCustomizer errorResponseExampleCustomizer;
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        ApiErrorResponse apiErrorResponseAnnotation = handlerMethod.getMethodAnnotation(ApiErrorResponse.class);
+        ApiErrorResponses apiErrorResponsesAnnotation = handlerMethod.getMethodAnnotation(ApiErrorResponses.class);
+
+        if (apiErrorResponseAnnotation != null) {
+            generateErrorResponse(operation, apiErrorResponseAnnotation);
+        }
+
+        if (apiErrorResponsesAnnotation != null) {
+            generateErrorResponses(operation, apiErrorResponsesAnnotation);
+        }
+
+        return operation;
+    }
+
+    private void generateErrorResponse(Operation operation, ApiErrorResponse apiErrorResponseAnnotation) {
+        ErrorCode errorCode = getErrorCodeByApiErrorResponse(apiErrorResponseAnnotation);
+        String enumName = apiErrorResponseAnnotation.enumName();
+        errorResponseExampleCustomizer.generateErrorResponseExample(operation, errorCode, enumName);
+    }
+
+    private void generateErrorResponses(Operation operation, ApiErrorResponses apiErrorResponsesAnnotation) {
+        List<Map<ErrorCode, String>> errorCodeList = Arrays.stream(apiErrorResponsesAnnotation.value())
+                .map(apiErrorResponseAnnotation -> {
+                    ErrorCode errorCode = getErrorCodeByApiErrorResponse(apiErrorResponseAnnotation);
+                    if (errorCode != null) {
+                        return Map.of(errorCode, apiErrorResponseAnnotation.enumName());
+                    }
+                    return null;
+                })
+                .toList();
+
+        errorResponseExampleCustomizer.generateErrorResponseExample(operation, errorCodeList);
+    }
+
+    private ErrorCode getErrorCodeByApiErrorResponse(ApiErrorResponse apiErrorResponseAnnotation) {
+        Class<? extends ErrorCode> errorCodeClass = apiErrorResponseAnnotation.value();
+        String enumName = apiErrorResponseAnnotation.enumName();
+
+        @SuppressWarnings("unchecked")
+        Class<? extends Enum<?>> enumClass = (Class<? extends Enum<?>>) errorCodeClass;
+
+        return getEnumConstant(enumClass, enumName);
+    }
+
+    private <E extends Enum<E> & ErrorCode> ErrorCode getEnumConstant(Class<? extends Enum<?>> enumClass,
+                                                                      String enumName) {
+        try {
+            // 제네릭 타입으로 맞춰 Enum 상수 가져오기
+            @SuppressWarnings("unchecked")
+            Class<E> specificEnumClass = (Class<E>) enumClass;
+            return Enum.valueOf(specificEnumClass, enumName);
+        } catch (ClassCastException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/team2/finalproject/global/swagger/customizer/ErrorResponseExampleCustomizer.java
+++ b/src/main/java/com/team2/finalproject/global/swagger/customizer/ErrorResponseExampleCustomizer.java
@@ -1,0 +1,69 @@
+package com.team2.finalproject.global.swagger.customizer;
+
+import com.team2.finalproject.global.exception.errorcode.ErrorCode;
+import com.team2.finalproject.global.exception.response.ErrorResponse;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ErrorResponseExampleCustomizer {
+    public void generateErrorResponseExample(Operation operation, ErrorCode errorCode, String enumName) {
+        ApiResponses responses = operation.getResponses();
+
+        MediaType mediaType = new MediaType();
+        Example example = generateExample(errorCode);
+        mediaType.addExamples(enumName, example);
+        Content content = generateContent(mediaType);
+        ApiResponse apiResponse = generateApiResponse(content);
+
+        responses.addApiResponse(Integer.toString(errorCode.getHttpStatus().value()), apiResponse);
+    }
+
+    public void generateErrorResponseExample(Operation operation, List<Map<ErrorCode, String>> errorCodeList) {
+        ApiResponses responses = operation.getResponses();
+
+        Map<Integer, List<Map<ErrorCode, String>>> errorCodeExampleByStatus = errorCodeList.stream()
+                .collect(Collectors.groupingBy(map -> map.keySet().iterator().next().getHttpStatus().value()));
+
+        errorCodeExampleByStatus
+                .forEach((statusCode, list) -> {
+                    MediaType mediaType = new MediaType();
+                    list.forEach(map ->
+                            map.forEach((errorCode, enumName) -> {
+                                Example example = generateExample(errorCode);
+                                mediaType.addExamples(enumName, example);
+                            }));
+                    Content content = generateContent(mediaType);
+                    ApiResponse apiResponse = generateApiResponse(content);
+                    responses.addApiResponse(statusCode.toString(), apiResponse);
+                });
+    }
+
+    private ApiResponse generateApiResponse(Content content) {
+        ApiResponse apiResponse = new ApiResponse();
+        apiResponse.setContent(content);
+        return apiResponse;
+    }
+
+    private Content generateContent(MediaType mediaType) {
+        Content content = new Content();
+        content.addMediaType("application/json", mediaType);
+        return content;
+    }
+
+    private Example generateExample(ErrorCode errorCode) {
+        Example example = new Example();
+        ErrorResponse errorResponse = ErrorResponse.from(errorCode);
+        example.setValue(errorResponse);
+        example.setDescription(errorCode.getMessage());
+        return example;
+    }
+}


### PR DESCRIPTION
<!-- PR 예시 : Feat: Issues Template 및 Pull Request Template 추가 --!>
<!-- 라벨과 리뷰어를 등록해주세요. -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
CustomOperationCustomizer 작성 후 Swagger 관련 어노테이션 추가

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
같은 에러코드가 여러 개일 때, 맨 앞의 하나만 나오던 문제를 해결하기 위해 커스텀 어노테이션을 추가했습니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

### 

> 사용 방법은 SwaggerDeliveryDestinationController 인터페이스를 참고 하시면 됩니다.


기존 `@ApiResponses`와 `@ApiResponse`의 사용법과 유사합니다.
```java
@ApiErrorResponses({
        @ApiErrorResponse(value = SecurityErrorCode.class, enumName = "UNAUTHORIZED_ACCESS"),
        @ApiErrorResponse(value = CenterErrorCode.class, enumName = "NOT_FOUND_CENTER"),
        @ApiErrorResponse(value = DeliveryDestinationErrorCode.class, enumName = "NOT_FOUND_DELIVERY_DESTINATION")
})
```
`value`엔 에러에 해당되는 클래스를 추가하고, `enumName`엔 에러코드 클래스 안에서 해당 되는 enum의 변수명을 적습니다.
자바 성능 상 Annotation에서 Enum을 받을 수 없던 관계로 불가피하게 클래스와 enumName을 받는 형식으로 변경했습니다.



## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
closed #71 
<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
https://dev-seonghun.medium.com/%EC%8A%A4%ED%94%84%EB%A7%81-%EB%B6%80%ED%8A%B8%EC%97%90%EC%84%9C-%EC%97%90%EB%9F%AC-%EC%8B%9C%EB%82%98%EB%A6%AC%EC%98%A4-%ED%85%8C%EC%8A%A4%ED%8A%B8%ED%95%98%EA%B8%B0-dcd9a9c6b3f0

https://bona-develop.tistory.com/entry/swagger-api-%EC%97%90%EB%9F%AC-%EC%83%81%EC%84%B8%ED%9E%88-%EB%82%B4%EB%A0%A4%EC%A3%BC%EA%B2%8C-%EC%BB%A4%EC%8A%A4%ED%85%80%ED%95%98%EA%B8%B0?category=1096558#1.%20%EC%BB%A4%EC%8A%A4%ED%85%80%20%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98%20%EC%83%9D%EC%84%B1-1